### PR TITLE
ear -> ear of corn

### DIFF
--- a/imagenet-simple-labels.json
+++ b/imagenet-simple-labels.json
@@ -996,5 +996,5 @@
 "earth star",
 "hen-of-the-woods",
 "bolete",
-"ear",
+"ear of corn",
 "toilet paper"]


### PR DESCRIPTION
The "ear" in class 998 really means "ear of corn".

See [here](https://knowyourdata-tfds.withgoogle.com/#dataset=imagenet2012&filters=default_segment.imagenet2012.label.value:%5Bear%2C%20spike%2C%20capitulum%5D(http%3A%2F%2Fwordnet-rdf.princeton.edu%2Fwn30%2F13133613-n)&tab=STATS&select=default_segment.imagenet2012.label.value&expanded_groups=imagenet2012).

"ear" by itself implies an anatomical ear (body part).