### PR TITLE
Brittany -> Brittany Spaniel

### DIFF
--- a/imagenet-simple-labels.json
+++ b/imagenet-simple-labels.json
@@ -213,7 +213,7 @@
 "English Setter",
 "Irish Setter",
 "Gordon Setter",
-"Brittany",
+"Brittany Spaniel",
 "Clumber Spaniel",
 "English Springer Spaniel",
 "Welsh Springer Spaniel",


### PR DESCRIPTION
to match the other "spaniels"

Sorry for being annoying, but I've been using this list you made to evaluate text-to-image models since your labels are much better than the wordnet classes.

And "Photo of Brittany" without the "Spaniel" yields images like this:
![image](https://github.com/anishathalye/imagenet-simple-labels/assets/18726777/5069a113-0967-4105-9a71-ecbbc17c0b2c)
